### PR TITLE
fix(cli): avoid race condition preventing reporting some queries

### DIFF
--- a/lua/cli/kulala_cli.lua
+++ b/lua/cli/kulala_cli.lua
@@ -163,7 +163,7 @@ local get_requests = function()
 end
 
 local function is_last()
-  return #Cmd.queue.tasks == 0
+  return Cmd.queue.done == Cmd.queue.total
 end
 
 local function run_file(file)


### PR DESCRIPTION
Listing the queries in the basic demo correctly yields 6 queries:

```
kulala_cli.lua 1.basic.http --list   

File: /app/kulala.nvim/docs/static/import/demos/1.basic.http
Line Name                                    URL                                               
 4    Simple GET request                      GET https://httpbin.org/get                      
 8    GET with query parameters               GET https://httpbin.org/get?name=kulala&age=25   
 12   POST with JSON body                     POST https://httpbin.org/post                    
 22   PUT with headers                        PUT https://httpbin.org/put                      
 33   DELETE request                          DELETE https://httpbin.org/delete                
 37   GET with multiple headers               GET https://httpbin.org/headers                  
```

but running the tests only finished 5:

```
kulala_cli.lua 1.basic.http -v report

..................................................*...............................................*...............................................................*...............................
................*..............................................*

Line URL                                               Status  Time      Duration       

 4    https://httpbin.org/get                           200     11:46:29  404.15 ms     

 8    https://httpbin.org/get?name=kulala&age=25        200     11:46:30  518.17 ms     

 12   https://httpbin.org/post                          200     11:46:32  1642.42 ms    

 22   https://httpbin.org/put                           200     11:46:32  414.43 ms     

 33   https://httpbin.org/delete                        200     11:46:32  404.90 ms     

Summary             Total               Successful          Failed              
 Requests            5                   5                   0                  
 Asserts             0                   0                   0                  
.
Status: OK
```

This is because is_last returns true when all tasks are scheduled but do not check if they are actually done. If the last task is not finished quickly enough then it is not reported.

This fix checks if the amount of tasks done is equal to the total tasks scheduled